### PR TITLE
fix: buffer size exceeds limits due to large arrays in the accumulator

### DIFF
--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -59,10 +59,10 @@ jobs:
         run: |
           source env/bin/activate
           run_pipeline --source=${{ secrets.BUCKET }}/raw \
-            --output=gs://${{ secrets.BUCKET }}/primary/neurips-dataset-c1d1f1m1b30sum.tfrecords \
+            --output=gs://${{ secrets.BUCKET }}/primary/ \
             --mask --flat --corr --dark \
             --runner=${{ vars.RUNNER}} \
-            --worker_disk_type=compute.googleapis.com/projects/${{ secrets.PROJECT_ID }}/zones/${{ secrets.REGION }}/diskTypes/pd-ssd \
+            --worker_disk_type=compute.googleapis.com/projects/${{ secrets.PROJECT_ID }}/zones/${{ secrets.REGION }}/diskTypes/pd-standard \
             --project=${{ secrets.PROJECT_ID }} \
             --region=${{ secrets.REGION }} \
             --temp_location=gs://${{ secrets.BUCKET }}/pipeline_root/ \


### PR DESCRIPTION
fix: buffer size exceeds limits due to large arrays in the accumulator

- Modify --output argument in the etl.yml workflow file
- refactor the code so that only collection metadata (filenames) are maintained in buffer
- Update machine configuration to fit in GCP quota limits
- Add a time stamping in the created files' path